### PR TITLE
Added support for installing pynotify when inotify beacons are config…

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -21,6 +21,7 @@ salt:
     salt-syndic: 'salt-syndic'
     salt-cloud: 'salt-cloud'
     salt-ssh: 'salt-ssh'
+    pyinotify: 'python-pyinotify' the package to be installed for pyinotify
 
   # Set which release of SaltStack to use, default to 'latest'
   # To get the available releases:

--- a/salt/map.jinja
+++ b/salt/map.jinja
@@ -47,6 +47,7 @@ that differ from whats in defaults.yaml
       salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease)|string + '/amd64/' + salt_release + ' ' + salt['grains.get']('oscodename') + ' main',
       'key_url': 'https://repo.saltstack.com/apt/' + salt['grains.get']('os')|lower + '/' + salt['grains.get']('osmajorrelease', osrelease)|string + '/amd64/' + salt_release  + '/SALTSTACK-GPG-KEY.pub',
       'libgit2': 'libgit2-22',
+      'pyinotify': 'python-pyinotify',
       'gitfs': {
         'pygit2': {
           'install_from_source': True,

--- a/salt/minion.sls
+++ b/salt/minion.sls
@@ -63,6 +63,16 @@ restart-salt-minion:
       - file: remove-old-minion-conf-file
 {%- endif %}
 
+{% if 'inotify' in  salt_settings.get('minion', {}).get('beacons', {}) and salt_settings.get('pyinotify', False) %}
+salt-minion-beacon-inotify:
+  pkg.installed:
+    - name: {{ salt_settings.pyinotify }}
+    - require_in:
+      - service: salt-minion
+    - watch_in:
+      - service: salt-minion
+{% endif %}
+
 {% if salt_settings.minion_remove_config %}
 remove-default-minion-conf-file:
   file.absent:


### PR DESCRIPTION
This PR adds support for installing `pynotify` when `inotify` beacons are configured on the minion. `pyinotify` is a required dependency for the `inotify` beacons to work.

The `pyinotify` package name is configurable with the `salt:lookup:pyinotify` pillar value. It will only install the package if the package name is configured and if inotify beacons are used. The default package name is configured for Debian based systems only.